### PR TITLE
ensuring gitignored filenames are exact, using $

### DIFF
--- a/__tests__/gitignored.js
+++ b/__tests__/gitignored.js
@@ -12,7 +12,7 @@ describe('lib/gitignored', () => {
   })
 
   it('.gitignoredRegExpString() returns a string that is a regexp that matches all entries from array', () => {
-    expect(regExpStr).toBe(`(node_modules|\\.DS_Store|(.+)\\.log|\\.git)`)
+    expect(regExpStr).toBe(`(node_modules|\\.DS_Store|(.+)\\.log|\\.git)$`)
   })
 
   it('.gitignoreRegExp() returns a regexp', () => {

--- a/lib/gitignored.js
+++ b/lib/gitignored.js
@@ -17,11 +17,11 @@ module.exports.getGitignored = function(gitignorePath) {
 }
 
 const gitignoredRegExpString = function(gitignored) {
-  return gitignored.reduce((regex, rule, index) => {
+  return `${gitignored.reduce((regex, rule, index) => {
     return index === gitignored.length - 1 ? `${regex}${rule})` : `${regex}${rule}|`
   }, '(')
     .replace(/\./g, '\\.')
-    .replace(/\*/g, '(.+)')
+    .replace(/\*/g, '(.+)')}$`
 }
 module.exports.gitignoredRegExpString = gitignoredRegExpString
 


### PR DESCRIPTION
previously, the gitignore functionality of apply-template was ignoring files that partially matched token in .gitignore. for instance, I had `.config` in my .gitignore: 
```
DEBUG="*" npx apply-template a-service test-service
applying template 'a-service' to 'test-service'
Found the following template variables:

     SERVICE_NAME

  apply-template applying template +0ms
  apply-template resolvedVariables +1ms
  apply-template {} +0ms
  apply-template getting user input +0ms
  apply-template asking for input for SERVICE_NAME +0ms
Enter a value for 'SERVICE_NAME': test-service
  apply-template received input test-service +5s
  apply-template filter /Users/matt/development/x/templates/a-service true +5s
  apply-template filter /Users/matt/development/x/templates/a-service/.babelrc true +1ms
  apply-template filter /Users/matt/development/x/templates/a-service/.editorconfig true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/.eslintrc true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/.git false +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/.gitignore true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/Dockerfile true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/Dockerfile.cloud true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/Dockerfile.mac true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/Makefile true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/README.md true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/__tests__ true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/config.js true +1ms
  apply-template filter /Users/matt/development/x/templates/a-service/docker-compose.build.yml true +0ms
  apply-template filter /Users/matt/development/x/templates/a-service/jest.config.js false +0ms <--------------------------------------------
  apply-template filter /Users/matt/development/x/templates/a-service/package-lock.json true +0ms
```
this fix ensures partial matches don't exclude files. 